### PR TITLE
Remove libcarthage

### DIFF
--- a/base-q.xml
+++ b/base-q.xml
@@ -10,7 +10,6 @@
   <project groups="kai" name="gecko-b2g" path="gecko" remote="kaios" revision="gonk"/>
   <project groups="kai" name="gonk-misc" path="gonk-misc" remote="kaios" revision="main"/>
   <project groups="kai" name="hidl-gen" path="system/tools/hidl" remote="kaios" revision="master"/>
-  <project groups="kai" name="libcarthage" path="gonk-misc/libcarthage" remote="kaios" revision="android_10"/>
   <project groups="kai" name="gonk-binder" path="gonk-misc/gonk-binder" remote="kaios" revision="master"/>
   
   <!-- Fake impl. for AOSP -->


### PR DESCRIPTION
It was moved back into Gecko instead of being a standalone library.